### PR TITLE
Feature/cs203 301/account creation

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,24 +5,41 @@ export const appRoutes: Routes = [
   // routing to home page
   {
     path: 'home',
-    loadChildren: () => import('./feature/home/home.module').then(m => m.HomeModule)
+    loadChildren: () =>
+      import('./feature/home/home.module').then((m) => m.HomeModule),
   },
   {
-    path: '', redirectTo: '/home', pathMatch: 'full'
+    path: '',
+    redirectTo: '/home',
+    pathMatch: 'full',
   },
   // event-routing
   {
     path: 'events',
-    loadChildren: () => import('./feature/events/events.module').then(m => m.EventsModule)
+    loadChildren: () =>
+      import('./feature/events/events.module').then((m) => m.EventsModule),
   },
   // event-register routing
   {
     path: 'events/register',
-    canActivateChild:[eventRegisterGuard()],
-    loadChildren: () => import('./feature/events-register/events-register.module').then(m => m.EventsRegisterModule)
+    canActivateChild: [eventRegisterGuard()],
+    loadChildren: () =>
+      import('./feature/events-register/events-register.module').then(
+        (m) => m.EventsRegisterModule
+      ),
+  },
+  // user-register
+  {
+    path: 'user',
+    loadChildren: () =>
+      import('./feature/user-register/user-register.module').then(
+        (m) => m.UserRegistrationModule
+      ),
   },
   // Route all other paths to home page.
   {
-    path: '**', redirectTo: '/home', pathMatch: 'full'
+    path: '**',
+    redirectTo: '/home',
+    pathMatch: 'full',
   },
 ];

--- a/src/app/feature/events-register/components/group-register-invite/group-register-invite.component.ts
+++ b/src/app/feature/events-register/components/group-register-invite/group-register-invite.component.ts
@@ -1,13 +1,11 @@
 import {
+  AfterViewInit,
   Component,
-  Output,
   EventEmitter,
   Input,
-  OnInit,
-  AfterViewInit,
+  Output
 } from '@angular/core';
-import { Form, FormControl } from '@angular/forms';
-import { Observable } from 'rxjs';
+import { FormControl } from '@angular/forms';
 import { GetUserInfoService } from 'src/app/shared/services/get-user-info/get-user-info.service';
 
 @Component({

--- a/src/app/feature/events-register/events-register.module.ts
+++ b/src/app/feature/events-register/events-register.module.ts
@@ -1,16 +1,16 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { DropdownModule } from 'primeng/dropdown';
 import { SharedModule } from 'src/app/shared/shared.module';
+import { GaRegistrationPopupComponent } from './components/ga-registration-popup/ga-registration-popup.component';
 import { GroupRegisterInviteComponent } from './components/group-register-invite/group-register-invite.component';
+import { QueueTimingPopupComponent } from './components/registration-confirmation-popup/queue-timing-popup';
 import { eventRegisterRoutes } from './events-register.routing';
 import { GroupRegistrationComponent } from './pages/group-registration/group-registration.component';
-import { RegistrationPreviewComponent } from './pages/registration-preview/registration-preview.component';
-import { QueueTimingPopupComponent } from './components/registration-confirmation-popup/queue-timing-popup';
-import { ReactiveFormsModule } from '@angular/forms';
 import { QueueTimingsComponent } from './pages/queue-timings/queue-timings.component';
-import { GaRegistrationPopupComponent } from './components/ga-registration-popup/ga-registration-popup.component';
-import { Dropdown, DropdownModule } from 'primeng/dropdown';
+import { RegistrationPreviewComponent } from './pages/registration-preview/registration-preview.component';
 
 @NgModule({
   declarations: [

--- a/src/app/feature/home/pages/landing-page/landing-page.component.ts
+++ b/src/app/feature/home/pages/landing-page/landing-page.component.ts
@@ -1,9 +1,6 @@
-import { GaVerificationPopupComponent } from 'src/app/shared/components/ga-verification-popup/ga-verification-popup.component';
 import { Component, OnInit } from '@angular/core';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { AuthenticationService } from 'src/app/core/services/authentication/authentication.service';
 import { MessageService } from 'primeng/api';
-import { GetEventInfoService } from 'src/app/shared/services/get-event-info/get-event-info-service';
+import { AuthenticationService } from 'src/app/core/services/authentication/authentication.service';
 
 @Component({
   selector: 'app-landing-page',

--- a/src/app/feature/user-register/pages/account-creation/account-creation.component.html
+++ b/src/app/feature/user-register/pages/account-creation/account-creation.component.html
@@ -1,1 +1,58 @@
-<p>account-creation works!</p>
+<app-header></app-header>
+<div class="container">
+  <h1>Sign up</h1>
+  <form [formGroup]="signUpForm">
+    <div class="input-fields">
+      <div class="email-field">
+        <app-input-field
+          placeholder="Email"
+          inputType="email"
+          [inputValue]="emailFC"
+        ></app-input-field>
+        <div *ngIf="userHasExistingAccount" class="failure-message">
+          <img
+            src="assets/icons/failure.svg"
+            alt="User has an existing account"
+            class="failure-icon"
+          />
+          <div class="verify-email">User has an existing account</div>
+        </div>
+      </div>
+      <div class="mobile-field">
+        <app-input-field
+          placeholder="Mobile with prefix"
+          inputType="mobile"
+          [inputValue]="mobileFC"
+        ></app-input-field>
+        <app-text-button
+          *ngIf="showOTPButton"
+          buttonText="Get OTP"
+          buttonVariants="primary"
+        ></app-text-button>
+      </div>
+      <app-input-field
+        placeholder="Create a password"
+        inputType="password"
+        [inputValue]="password1FC"
+      ></app-input-field>
+      <div class="password-retype-field">
+        <app-input-field
+          placeholder="Retype your password"
+          inputType="password"
+          [inputValue]="password2FC"
+        ></app-input-field>
+        <div *ngIf="!passwordsMatch" class="password-error">
+          <img
+            src="assets/icons/failure.svg"
+            alt="User has an existing account"
+            class="failure-icon"
+          />
+          <div>Passwords do not match</div>
+        </div>
+      </div>
+    </div>
+  </form>
+  <div class="next-button">
+      <app-text-button *ngIf="showNextButton" buttonVariants="primary" buttonText="Next"></app-text-button>
+  </div>
+</div>

--- a/src/app/feature/user-register/pages/account-creation/account-creation.component.html
+++ b/src/app/feature/user-register/pages/account-creation/account-creation.component.html
@@ -1,0 +1,1 @@
+<p>account-creation works!</p>

--- a/src/app/feature/user-register/pages/account-creation/account-creation.component.html
+++ b/src/app/feature/user-register/pages/account-creation/account-creation.component.html
@@ -36,6 +36,7 @@
           *ngIf="showOTPButton"
           buttonText="Get OTP"
           buttonVariants="primary"
+          (buttonClick)="showOTPPopup()"
         ></app-text-button>
       </div>
       <app-input-field

--- a/src/app/feature/user-register/pages/account-creation/account-creation.component.html
+++ b/src/app/feature/user-register/pages/account-creation/account-creation.component.html
@@ -24,6 +24,14 @@
           inputType="mobile"
           [inputValue]="mobileFC"
         ></app-input-field>
+        <div *ngIf="mobileNumberExists" class="failure-message">
+          <img
+            src="assets/icons/failure.svg"
+            alt="Mobile number already exists"
+            class="failure-icon"
+          />
+          <div class="verify-email">Mobile number already exists</div>
+        </div>
         <app-text-button
           *ngIf="showOTPButton"
           buttonText="Get OTP"
@@ -53,6 +61,10 @@
     </div>
   </form>
   <div class="next-button">
-      <app-text-button *ngIf="showNextButton" buttonVariants="primary" buttonText="Next"></app-text-button>
+    <app-text-button
+      *ngIf="checkNextButton()"
+      buttonVariants="primary"
+      buttonText="Next"
+    ></app-text-button>
   </div>
 </div>

--- a/src/app/feature/user-register/pages/account-creation/account-creation.component.scss
+++ b/src/app/feature/user-register/pages/account-creation/account-creation.component.scss
@@ -1,0 +1,59 @@
+@import "/src/styles.scss";
+
+.container {
+  padding-left: 89px;
+  padding-top: 44px;
+  padding-right: 89px;
+  padding-bottom: 44px;
+}
+
+.input-fields {
+  display: flex;
+  flex-direction: column;
+  row-gap: 25px;
+  margin-top: 40px;
+}
+
+.email-field {
+  display: flex;
+  flex-direction: row;
+  column-gap: 15px;
+}
+
+.mobile-field {
+  display: flex;
+  flex-direction: row;
+  column-gap: 15px;
+}
+
+.failure-message {
+  display: flex;
+  flex-direction: row;
+  column-gap: 5px;
+  align-items: center;
+}
+
+.failure-icon {
+  width: 24px;
+  height: 24px;
+}
+
+.password-retype-field {
+    display: flex;
+    flex-direction: row;
+    column-gap: 15px;
+    align-items: center;
+}
+
+.password-error {
+    display: flex;
+    flex-direction: row;
+    column-gap: 5px;
+    -webkit-text-fill-color: $error-2;
+}
+
+.next-button {
+    margin-top: 40px;
+    display: flex;
+    justify-content: end;
+}

--- a/src/app/feature/user-register/pages/account-creation/account-creation.component.spec.ts
+++ b/src/app/feature/user-register/pages/account-creation/account-creation.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccountCreationComponent } from './account-creation.component';
+
+describe('AccountCreationComponent', () => {
+  let component: AccountCreationComponent;
+  let fixture: ComponentFixture<AccountCreationComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [AccountCreationComponent]
+    });
+    fixture = TestBed.createComponent(AccountCreationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/feature/user-register/pages/account-creation/account-creation.component.ts
+++ b/src/app/feature/user-register/pages/account-creation/account-creation.component.ts
@@ -2,9 +2,10 @@ import { Component, OnInit } from '@angular/core';
 import {
   FormBuilder,
   FormControl,
-  FormGroup,
-  Validators,
+  FormGroup
 } from '@angular/forms';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { OtpPopupComponent } from 'src/app/shared/components/otp-popup/otp-popup.component';
 import { GetUserInfoService } from 'src/app/shared/services/get-user-info/get-user-info.service';
 
 @Component({
@@ -15,7 +16,6 @@ import { GetUserInfoService } from 'src/app/shared/services/get-user-info/get-us
 export class AccountCreationComponent implements OnInit {
   showOTPButton: boolean = false;
   userHasExistingAccount: boolean = false;
-  // to check if mobile number exists
   mobileNumberExists: boolean = false;
   passwordsMatch: boolean = true;
   otpVerified: boolean = false;
@@ -27,7 +27,8 @@ export class AccountCreationComponent implements OnInit {
 
   constructor(
     private fb: FormBuilder,
-    private getUserInfoService: GetUserInfoService
+    private getUserInfoService: GetUserInfoService,
+    private ngbModal: NgbModal
   ) {
     this.signUpForm = fb.group({});
   }
@@ -91,9 +92,16 @@ export class AccountCreationComponent implements OnInit {
     }
   }
 
+  showOTPPopup(): void {
+    const modalRef = this.ngbModal.open(OtpPopupComponent, { centered: true });
+    modalRef.componentInstance.mobileVerified.subscribe((value: boolean) => {
+      this.otpVerified = value;
+    });
+  }
+
   checkNextButton(): boolean {
     // temporary, until we implement OTP
-    this.otpVerified = true;
+    // this.otpVerified = true;
     if (
       !this.userHasExistingAccount &&
       this.passwordsMatch &&

--- a/src/app/feature/user-register/pages/account-creation/account-creation.component.ts
+++ b/src/app/feature/user-register/pages/account-creation/account-creation.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-account-creation',
+  templateUrl: './account-creation.component.html',
+  styleUrls: ['./account-creation.component.scss']
+})
+export class AccountCreationComponent {
+
+}

--- a/src/app/feature/user-register/pages/account-creation/account-creation.component.ts
+++ b/src/app/feature/user-register/pages/account-creation/account-creation.component.ts
@@ -1,10 +1,90 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import {
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
+import { GetUserInfoService } from 'src/app/shared/services/get-user-info/get-user-info.service';
 
 @Component({
   selector: 'app-account-creation',
   templateUrl: './account-creation.component.html',
-  styleUrls: ['./account-creation.component.scss']
+  styleUrls: ['./account-creation.component.scss'],
 })
-export class AccountCreationComponent {
+export class AccountCreationComponent implements OnInit {
+  showOTPButton: boolean = false;
+  userHasExistingAccount: boolean = false;
+  passwordsMatch: boolean = true;
+  showNextButton: boolean = false;
+  otpVerified: boolean = false;
+  signUpForm: FormGroup;
+  emailFC: FormControl = new FormControl('');
+  mobileFC: FormControl = new FormControl('');
+  password1FC: FormControl = new FormControl('');
+  password2FC: FormControl = new FormControl('');
 
+  constructor(
+    private fb: FormBuilder,
+    private getUserInfoService: GetUserInfoService
+  ) {
+    this.signUpForm = fb.group({});
+  }
+
+  ngOnInit(): void {
+    this.signUpForm.addControl('email', this.emailFC);
+    this.signUpForm.addControl('mobile', this.mobileFC);
+    this.signUpForm.addControl('password1', this.password1FC);
+    this.signUpForm.addControl('password2', this.password2FC);
+  }
+
+  ngAfterViewInit(): void {
+    this.signUpForm.get('email')?.valueChanges.subscribe((value) => {
+      this.verifyEmail();
+    });
+    this.signUpForm.get('mobile')?.valueChanges.subscribe((value) => {
+      this.handleShowOTPButton();
+    });
+    this.signUpForm.get('password2')?.valueChanges.subscribe((value) => {
+      this.checkIfPasswordsMatch();
+      this.checkNextButton();
+    })
+  }
+
+  async verifyEmail() {
+    if (this.signUpForm.get('email')?.valid) {
+      await this.getUserInfoService
+        .loadUserInfo(this.signUpForm.get('email')?.value)
+        .subscribe((value) => {
+          if (value) {
+            this.userHasExistingAccount = true;
+          }
+        });
+    }
+  }
+
+  checkIfPasswordsMatch(): void {
+    if (this.signUpForm.get('password1')?.value !== this.signUpForm.get('password2')?.value) {
+      this.passwordsMatch = false;
+    } else {
+      this.passwordsMatch = true;
+    }
+  }
+
+  handleShowOTPButton(): void {
+    if (this.signUpForm.get('mobile')?.valid) {
+      this.showOTPButton = true;
+    }
+  }
+
+  checkNextButton(): void {
+    // temporary, until we implement OTP
+    this.otpVerified = true;
+    
+    if (!this.userHasExistingAccount && this.passwordsMatch && this.otpVerified) {
+      this.showNextButton = true;
+    } else {
+      this.showNextButton = false;
+    }
+  }
 }

--- a/src/app/feature/user-register/user-register.module.ts
+++ b/src/app/feature/user-register/user-register.module.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { userRegisterRoutes } from './user-register.routing';
 import { CommonModule } from '@angular/common';
 import { SharedModule } from 'src/app/shared/shared.module';
+import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
   declarations: [AccountCreationComponent],

--- a/src/app/feature/user-register/user-register.module.ts
+++ b/src/app/feature/user-register/user-register.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { AccountCreationComponent } from './pages/account-creation/account-creation.component';
+import { RouterModule } from '@angular/router';
+import { userRegisterRoutes } from './user-register.routing';
+
+@NgModule({
+  declarations: [AccountCreationComponent],
+  imports: [RouterModule.forChild(userRegisterRoutes)],
+})
+export class UserRegistrationModule {}

--- a/src/app/feature/user-register/user-register.module.ts
+++ b/src/app/feature/user-register/user-register.module.ts
@@ -2,9 +2,15 @@ import { NgModule } from '@angular/core';
 import { AccountCreationComponent } from './pages/account-creation/account-creation.component';
 import { RouterModule } from '@angular/router';
 import { userRegisterRoutes } from './user-register.routing';
+import { CommonModule } from '@angular/common';
+import { SharedModule } from 'src/app/shared/shared.module';
 
 @NgModule({
   declarations: [AccountCreationComponent],
-  imports: [RouterModule.forChild(userRegisterRoutes)],
+  imports: [
+    RouterModule.forChild(userRegisterRoutes),
+    CommonModule,
+    SharedModule,
+  ],
 })
 export class UserRegistrationModule {}

--- a/src/app/feature/user-register/user-register.routing.ts
+++ b/src/app/feature/user-register/user-register.routing.ts
@@ -1,0 +1,9 @@
+import { Routes } from "@angular/router";
+import { AccountCreationComponent } from "./pages/account-creation/account-creation.component";
+
+export const userRegisterRoutes: Routes = [
+    {
+        path: 'register',
+        component: AccountCreationComponent
+    }
+]

--- a/src/app/shared/components/input-field/input-field.component.scss
+++ b/src/app/shared/components/input-field/input-field.component.scss
@@ -9,7 +9,7 @@
     height: 40px;
     width: 300px;
     border-radius: 5px;
-    border-style: $gray-2;
+    border-style: $gray-3;
     border-style: solid;
     border-width: 1px;
     padding: 8px;

--- a/src/app/shared/components/login-popup/login-popup.component.html
+++ b/src/app/shared/components/login-popup/login-popup.component.html
@@ -53,6 +53,6 @@
         (buttonClick)="loginUser()"
       ></app-text-button>
     </div>
-    <!-- <div class="login-text join-us">Not a member? Join us</div> -->
+    <button class="login-text join-us" (click)="handleRegisterClick()" (click)="activeModal.dismiss('Cross click')">Not a member? Join us</button>
   </div>
 </div>

--- a/src/app/shared/components/login-popup/login-popup.component.scss
+++ b/src/app/shared/components/login-popup/login-popup.component.scss
@@ -10,6 +10,12 @@
   margin-top: 40px;
 }
 
+.modal-body {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+}
+
 .input-fields {
   display: flex;
   justify-content: center;
@@ -50,4 +56,6 @@
 
 .join-us {
   margin-bottom: 20px;
+  border-width: 0px;
+  background-color: transparent;
 }

--- a/src/app/shared/components/login-popup/login-popup.component.spec.ts
+++ b/src/app/shared/components/login-popup/login-popup.component.spec.ts
@@ -1,12 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { LoginPopupComponent } from './login-popup.component';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { InputFieldComponent } from '../input-field/input-field.component';
-import { TextButtonComponent } from '../text-button/text-button.component';
-import { SharedModule } from '../../shared.module';
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { SharedModule } from '../../shared.module';
+import { LoginPopupComponent } from './login-popup.component';
 
 describe('LoginPopupComponent', () => {
   let component: LoginPopupComponent;

--- a/src/app/shared/components/login-popup/login-popup.component.ts
+++ b/src/app/shared/components/login-popup/login-popup.component.ts
@@ -4,6 +4,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { AuthenticationService } from 'src/app/core/services/authentication/authentication.service';
 import { GetUserInfoService } from '../../services/get-user-info/get-user-info.service';
 import { User } from 'src/app/models/user';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-login-popup',
@@ -24,7 +25,8 @@ export class LoginPopupComponent implements OnInit {
     public activeModal: NgbActiveModal,
     private fb: FormBuilder,
     private authService: AuthenticationService,
-    private getUserInfoService: GetUserInfoService
+    private getUserInfoService: GetUserInfoService,
+    private router: Router
   ) {
     this.loginFG = this.fb.group({
       email: this.emailFC,
@@ -47,30 +49,8 @@ export class LoginPopupComponent implements OnInit {
       .subscribe(
         (data: string | boolean) => {
           // User gets a JWT token
-          // console.log(data);
           if (typeof data == typeof '') {
             this.authService.saveAuthToken(JSON.parse(JSON.stringify(data)));
-
-            // Hardcoded user, we got CORS errors.
-            // const user: User = {
-            //   userID : "2",
-            //   mobileNo : "06598231539",
-            //   email : "jrteo.2022@smu.edu.sg",
-            //   authenticatorID: "002",
-            //   "isVerified": true
-            // };
-            // console.log(user);
-
-            // this.authService.user = user;
-
-            // this.loginFG.reset();
-            // // Dismiss this active modal
-            // this.activeModal.dismiss();
-            // // Authenticate user
-            // this.authService.authenticateUser().then((data: boolean) => {
-            //   // Log in user
-            //   this.authService.email = email;
-            // });
 
             // Make another call to get the user object --> quite inefficient for now. But possibly can refactor.
             this.getUserInfoService.loadUserInfo(email).subscribe(
@@ -146,5 +126,9 @@ export class LoginPopupComponent implements OnInit {
     let mobile: string = this.mobileFC.value;
     mobile = mobile.replace('+', '0');
     return mobile;
+  }
+
+  handleRegisterClick(): void {
+    this.router.navigate(['/user', 'register']);
   }
 }

--- a/src/app/shared/components/login-popup/login-popup.component.ts
+++ b/src/app/shared/components/login-popup/login-popup.component.ts
@@ -41,7 +41,7 @@ export class LoginPopupComponent implements OnInit {
   loginUser(): void {
     if (!this._fieldsAllValid()) return;
 
-    // Process mobile number.
+    // Process mobile number
     let mobile = this.processMobile();
     let email = this.emailFC.value;
     this.authService

--- a/src/app/shared/components/otp-popup/otp-popup.component.html
+++ b/src/app/shared/components/otp-popup/otp-popup.component.html
@@ -1,0 +1,31 @@
+<div>
+  <div class="modal-header">
+    <button
+      type="button"
+      aria-label="Close"
+      class="btn-close"
+      (click)="activeModal.dismiss('Cross click')"
+    ></button>
+  </div>
+  <div class="modal-body">
+    <div class="auth-description">
+      Please enter the OTP to verify your mobile number
+    </div>
+    <div class="otp-input-field">
+        <app-input-field
+          inputType="auth-code"
+          placeholder="Enter OTP"
+          [inputValue]="otpFC"
+        ></app-input-field>
+    </div>
+    <div class="validate-button">
+      <app-text-button
+        buttonVariants="primary"
+        buttonText="Validate OTP"
+        (buttonClick)="handleVerify()"
+        (click)="activeModal.dismiss('Cross click')"
+      ></app-text-button>
+      <button class="resend-otp">Resend OTP</button>
+    </div>
+  </div>
+</div>

--- a/src/app/shared/components/otp-popup/otp-popup.component.scss
+++ b/src/app/shared/components/otp-popup/otp-popup.component.scss
@@ -1,0 +1,31 @@
+@import "/src/styles.scss";
+
+.modal-body {
+    display: flex;
+    flex-direction: column;
+    row-gap: 20px;
+    justify-content: center;
+    margin-top: 20px;
+    text-align: center;
+}
+
+.otp-input-field {
+    display: flex;
+    justify-content: center;
+}
+
+.validate-button {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    row-gap: 8px;
+}
+
+.resend-otp {
+  border-width: 0px;
+  margin-bottom: 20px;
+  background-color: transparent;
+  font-size: $sub-text-3-font-size;
+  font-weight: $sub-text-3-font-weight;
+  -webkit-text-fill-color: $gray-4;
+}

--- a/src/app/shared/components/otp-popup/otp-popup.component.spec.ts
+++ b/src/app/shared/components/otp-popup/otp-popup.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OtpPopupComponent } from './otp-popup.component';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { SharedModule } from '../../shared.module';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { HttpClient } from '@angular/common/http';
+
+describe('OtpPopupComponent', () => {
+  let component: OtpPopupComponent;
+  let fixture: ComponentFixture<OtpPopupComponent>;
+  let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [OtpPopupComponent],
+      imports: [SharedModule, HttpClientTestingModule],
+      providers: [NgbActiveModal],
+    });
+    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(OtpPopupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/otp-popup/otp-popup.component.ts
+++ b/src/app/shared/components/otp-popup/otp-popup.component.ts
@@ -1,0 +1,19 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'app-otp-popup',
+  templateUrl: './otp-popup.component.html',
+  styleUrls: ['./otp-popup.component.scss'],
+})
+export class OtpPopupComponent {
+  @Output() mobileVerified: EventEmitter<boolean> = new EventEmitter<boolean>();
+  otpFC: FormControl = new FormControl;
+  constructor(public activeModal: NgbActiveModal) {}
+
+  handleVerify(): void {
+    // otp verification here
+    this.mobileVerified.emit(true);
+  }
+}

--- a/src/app/shared/services/get-event-info/get-event-info-service.ts
+++ b/src/app/shared/services/get-event-info/get-event-info-service.ts
@@ -1,9 +1,7 @@
 import { Injectable } from '@angular/core';
-import { events } from 'src/app/mock-db/MockDB';
-import { Event } from '../../../models/event';
+import { Observable } from 'rxjs';
 import { BaseRestApiService } from 'src/app/core/services/base-rest-api/base-rest-api.service';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Event } from '../../../models/event';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/services/get-show-info/get-show-info.service.spec.ts
+++ b/src/app/shared/services/get-show-info/get-show-info.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-
 import { GetShowInfoService } from './get-show-info.service';
 
 describe('GetShowInfoService', () => {

--- a/src/app/shared/services/get-user-info/get-user-info.service.ts
+++ b/src/app/shared/services/get-user-info/get-user-info.service.ts
@@ -13,7 +13,21 @@ export class GetUserInfoService extends BaseRestApiService {
   }
 
   loadUserInfo(email: string): Observable<any> {
-    return this.get('users/'+ email);
+    return this.get('users/' + email);
+  }
+
+  // existingMobileNumber(mobile: string): Observable<any> {
+  existingMobileNumber(mobile: string): Promise<boolean> {
+    return Promise.resolve(this._checkMobile(mobile));
+  }
+
+  private _checkMobile(mobile: string): boolean {
+    for (let user of Users) {
+      if (user.mobileNo === mobile) {
+        return true;
+      }
+    }
+    return false;
   }
 
   getUserID(email: string, mobile: string): Promise<string | undefined> {
@@ -22,7 +36,7 @@ export class GetUserInfoService extends BaseRestApiService {
 
   private _getUserID(email: string, mobile: string): string | undefined {
     for (let user of Users) {
-      if (user.email == email && user.mobileNo == mobile) return user.userID;
+      if (user.email === email && user.mobileNo === mobile) return user.userID;
     }
     return undefined;
   }

--- a/src/app/shared/services/get-user-info/get-user-info.service.ts
+++ b/src/app/shared/services/get-user-info/get-user-info.service.ts
@@ -1,9 +1,8 @@
-import { HttpClient, HttpParams, HttpParamsOptions } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { BaseRestApiService } from 'src/app/core/services/base-rest-api/base-rest-api.service';
 import { Users } from 'src/app/mock-db/MockDB';
-import { User } from 'src/app/models/user';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -8,6 +8,7 @@ import { HeaderComponent } from './components/header/header.component';
 import { InputFieldComponent } from './components/input-field/input-field.component';
 import { TextButtonComponent } from './components/text-button/text-button.component';
 import { LoginPopupComponent } from './components/login-popup/login-popup.component';
+import { OtpPopupComponent } from './components/otp-popup/otp-popup.component';
 
 @NgModule({
   declarations: [
@@ -15,7 +16,8 @@ import { LoginPopupComponent } from './components/login-popup/login-popup.compon
     InputFieldComponent,
     HeaderComponent,
     GaVerificationPopupComponent,
-    LoginPopupComponent
+    LoginPopupComponent,
+    OtpPopupComponent
   ],
   imports: [
     CommonModule,
@@ -33,7 +35,8 @@ import { LoginPopupComponent } from './components/login-popup/login-popup.compon
     CarouselModule,
     GaVerificationPopupComponent,
     LoginPopupComponent,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    OtpPopupComponent
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
Steps to see account creation page

1. Click on login button in header
2. Click on 'Not a member? Join us'

I have created the conditional rendering of the buttons and error states
- If existing email is keyed in, will cause an error
- If existing mobile is keyed in, will cause an error -> get OTP button not shown as well
- I have also created the verify OTP popup: if you click on get OTP button, it should show up. **Please click verify otherwise the Next button will not be shown**
**- The API to check if mobile is currently in DB is not done yet, I have mocked one in the FE in the meantime**
- If passwords do not match, there will be an error
- If any error occurs in any of the fields, the Next button will not be shown